### PR TITLE
Add user recipes endpoints

### DIFF
--- a/app/controllers/api/v1/user_recipes_controller.rb
+++ b/app/controllers/api/v1/user_recipes_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::UserRecipesController < ApplicationController
+  def index
+    recipe_ids = UserRecipe.select(:recipe_id).where("user_id = ?", params[:user_id]).pluck(:recipe_id)
+
+    recipes = []
+
+    recipe_ids.each do |id|
+      data = RecipeService.new.recipes_by_id(id)
+      recipes << SearchedRecipe.new(data)
+    end
+
+    render json: SearchedRecipeSerializer.new(recipes)
+  end
+end

--- a/app/controllers/api/v1/user_recipes_controller.rb
+++ b/app/controllers/api/v1/user_recipes_controller.rb
@@ -3,4 +3,21 @@ class Api::V1::UserRecipesController < ApplicationController
     recipes = UserRecipesFacade.new(params[:user_id]).fetch_user_recipes
     render json: SearchedRecipeSerializer.new(recipes)
   end
+
+  def create
+    UserRecipe.create!(user_recipe_params)
+    render json: {}, status: 200
+  end
+
+  def destroy
+    user_recipe = UserRecipe.find_by(user_id: params[:user_id], recipe_id: params[:recipe_id])
+    user_recipe.destroy
+    render json: {}, status: 200
+  end
+
+  private
+
+  def user_recipe_params
+    params.permit(:user_id, :recipe_id)
+  end
 end

--- a/app/controllers/api/v1/user_recipes_controller.rb
+++ b/app/controllers/api/v1/user_recipes_controller.rb
@@ -1,14 +1,6 @@
 class Api::V1::UserRecipesController < ApplicationController
   def index
-    recipe_ids = UserRecipe.select(:recipe_id).where("user_id = ?", params[:user_id]).pluck(:recipe_id)
-
-    recipes = []
-
-    recipe_ids.each do |id|
-      data = RecipeService.new.recipes_by_id(id)
-      recipes << SearchedRecipe.new(data)
-    end
-
+    recipes = UserRecipesFacade.new(params[:user_id]).fetch_user_recipes
     render json: SearchedRecipeSerializer.new(recipes)
   end
 end

--- a/app/facades/user_recipes_facade.rb
+++ b/app/facades/user_recipes_facade.rb
@@ -1,0 +1,14 @@
+class UserRecipesFacade
+  def initialize(id)
+    @id = id
+  end
+
+  def fetch_user_recipes
+    recipe_ids = UserRecipe.all_recipes_by_user(@id)
+    service = RecipeService.new
+    
+    recipe_ids.map do |recipe_id|
+      SearchedRecipe.new(service.recipes_by_id(recipe_id))
+    end
+  end
+end

--- a/app/models/user_recipe.rb
+++ b/app/models/user_recipe.rb
@@ -1,4 +1,8 @@
 class UserRecipe < ApplicationRecord
   validates_presence_of :user_id
   validates_presence_of :recipe_id
+
+  def self.all_recipes_by_user(id)
+    UserRecipe.where("user_id = ?", id).pluck(:recipe_id)
+  end
 end

--- a/app/models/user_recipe.rb
+++ b/app/models/user_recipe.rb
@@ -1,0 +1,4 @@
+class UserRecipe < ApplicationRecord
+  validates_presence_of :user_id
+  validates_presence_of :recipe_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api do 
     namespace :v1 do 
       resources :search, only: [:index, :show]
+      resources :user_recipes, only: [:index, :create]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     namespace :v1 do 
       resources :search, only: [:index, :show]
       resources :user_recipes, only: [:index, :create]
+      delete "/user_recipes", to: "user_recipes#destroy" # hand-rolling to prevent a need for a UserRecipe ID
     end
   end
 end

--- a/db/migrate/20231107200754_create_user_recipes.rb
+++ b/db/migrate/20231107200754_create_user_recipes.rb
@@ -1,0 +1,10 @@
+class CreateUserRecipes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_recipes do |t|
+      t.integer :user_id
+      t.integer :recipe_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_07_200754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "user_recipes", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "recipe_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/facades/user_recipes_facade_spec.rb
+++ b/spec/facades/user_recipes_facade_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe UserRecipesFacade do
+  before(:each) do
+    @user_id = 1
+    @recipe1_id = 633386
+    UserRecipe.create!(user_id: @user_id, recipe_id: @recipe1_id)
+
+    @facade = UserRecipesFacade.new(@user_id)
+  end
+
+  it "exists" do
+    expect(@facade).to be_a UserRecipesFacade
+  end
+
+  it "can fetch all recipes given a user ID", :vcr do
+    results = @facade.fetch_user_recipes
+    expect(results).to be_an Array
+    expect(results.first.id).to eq(@recipe1_id)
+  end
+end

--- a/spec/models/user_recipe_spec.rb
+++ b/spec/models/user_recipe_spec.rb
@@ -5,4 +5,22 @@ RSpec.describe UserRecipe, type: :model do
     it {should validate_presence_of(:user_id)}
     it {should validate_presence_of(:recipe_id)}
   end
+
+  describe "class methods" do
+    describe "#all_recipes_by_user" do
+      it "returns an array of all recipes IDs for a given user ID" do
+        user_id = 1
+        recipe1_id = 10
+        recipe2_id = 12
+        recipe3_id = 1014
+        recipe4_id = 948
+        UserRecipe.create!(user_id: user_id, recipe_id: recipe1_id)
+        UserRecipe.create!(user_id: user_id, recipe_id: recipe2_id)
+        UserRecipe.create!(user_id: user_id, recipe_id: recipe3_id)
+
+        expect(UserRecipe.all_recipes_by_user(user_id)).to include([recipe1_id, recipe2_id, recipe3_id])
+        expect(UserRecipe.all_recipes_by_user(user_id)).to_not include(recipe4_id)
+      end
+    end
+  end
 end

--- a/spec/models/user_recipe_spec.rb
+++ b/spec/models/user_recipe_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe UserRecipe, type: :model do
+  describe "validations" do
+    it {should validate_presence_of(:user_id)}
+    it {should validate_presence_of(:recipe_id)}
+  end
+end

--- a/spec/requests/api/v1/user_recipes_request_spec.rb
+++ b/spec/requests/api/v1/user_recipes_request_spec.rb
@@ -30,4 +30,34 @@ RSpec.describe "User Recipes Endpoint", type: :request do
       expect(attributes[:img_src]).to be_a String
     end
   end
+
+  it "allows the creation of a new UserRecipe via a post" do
+    user_id = 1
+    recipe_id = 213
+
+    post "/api/v1/user_recipes?user_id=#{user_id}&recipe_id=#{recipe_id}"
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    user_recipe = UserRecipe.last
+    expect(user_recipe.user_id).to eq(user_id)
+    expect(user_recipe.recipe_id).to eq(recipe_id)
+  end
+
+  it "allows the deletion of a UserRecipe" do
+    user_id = 1
+    recipe_id = 213
+
+    post "/api/v1/user_recipes?user_id=#{user_id}&recipe_id=#{recipe_id}"
+
+    expect(UserRecipe.last).to be_a UserRecipe
+
+    delete "/api/v1/user_recipes?user_id=#{user_id}&recipe_id=#{recipe_id}"
+
+    expect(response).to be_successful
+    expect(response.status).to eq(200)
+
+    expect(UserRecipe.last).to be nil
+  end
 end

--- a/spec/requests/api/v1/user_recipes_request_spec.rb
+++ b/spec/requests/api/v1/user_recipes_request_spec.rb
@@ -60,4 +60,10 @@ RSpec.describe "User Recipes Endpoint", type: :request do
 
     expect(UserRecipe.last).to be nil
   end
+
+  describe "sad paths" do
+    xit "cannot add the same recipe twice" do
+      #todo
+    end
+  end
 end

--- a/spec/requests/api/v1/user_recipes_request_spec.rb
+++ b/spec/requests/api/v1/user_recipes_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "User Recipes Endpoint", type: :request do
+  it "should return an array of recipes given a user ID", :vcr do
+    recipe1 = UserRecipe.create!(user_id: 1, recipe_id: 633386)
+    recipe2 = UserRecipe.create!(user_id: 1, recipe_id: 663931)
+    recipe3 = UserRecipe.create!(user_id: 1, recipe_id: 663933)
+    recipe4 = UserRecipe.create!(user_id: 2, recipe_id: 1)
+
+    get "/api/v1/user_recipes?user_id=1"
+
+    expect(response).to be_successful
+
+    recipes_data = JSON.parse(response.body, symbolize_names: true)
+
+    recipes = recipes_data[:data]
+
+    recipes.each do |recipe|
+      expect(recipe).to have_key(:id)
+      expect(recipe[:id]).to be_a String
+    
+      expect(recipe).to have_key(:attributes)
+      expect(recipe[:attributes]).to be_a Hash
+
+      attributes = recipe[:attributes]
+
+      expect(attributes).to have_key(:name)
+      expect(attributes[:name]).to be_a String
+      expect(attributes).to have_key(:img_src)
+      expect(attributes[:img_src]).to be_a String
+    end
+  end
+end


### PR DESCRIPTION
Features:
- Adds a UserRecipes table
- Exposes a new /user_recipes endpoint with the following actions:
  - get: takes a user_id param and returns SearchedRecipes for that user
  - post: takes a user_id and recipe_id param, and creates a new UserRecipe, returns status 200
  - delete: takes a user_id and recipe_id param, finds and deletes any UserRecipe found, returns status 200

Testing:
- Full request testing for each endpoint
- Model testing for both validations and class methods on UserRecipe
- Facade testing for the UserRecipesFacade
- NO SADPATH TESTING

Other Notes:
- Only thing to declare here is traditionally we've used deletion endpoints that have a specific ID within the URI. I've gone the direction of passing query params instead and hitting a deletion endpoint on the collection itself, to avoid the need to pass a UserRecipe ID with each of the Recipes themselves back to the front end. I did some research, and from the fair number of threads/articles I found on this, it *is* acceptable, and RESTful guidelines don't make any statement against it.